### PR TITLE
Feat: Allow skipping test file generation

### DIFF
--- a/bin/styled-svg.js
+++ b/bin/styled-svg.js
@@ -29,6 +29,11 @@ const optionsDefinitions = [
     type: Boolean
   },
   {
+    name: 'skip-tests',
+    description: 'Skip test file generation',
+    type: Boolean
+  },
+  {
     name: 'output-dir',
     description: 'The directory to output components to. This defaults to the directory of the svg.',
     type: String
@@ -72,18 +77,18 @@ if (options.help || options._unknown) {
   ])
   console.log(usage)
 } else {
-  // shim friendly options
-  options.outputDir = options['output-dir']
-  options.testDir = options['test-dir']
-  options.templatesDir = options['templates-dir']
-  options.dryRun = options['dry-run']
+  // shim dashcase options to camelCase
+  const normalizedOptions = Object.entries(options).reduce((opts, [key, value]) => {
+    opts[key.replace(/-([a-z])/gi, g => g[1].toUpperCase())] = value
+    return opts
+  }, {})
 
   // execute on sources
   const globby = require('globby')
   const convert = require('..')
 
-  globby(options.input)
-    .then(files => convert(files, options))
+  globby(normalizedOptions.input)
+    .then(files => convert(files, normalizedOptions))
     .catch(err => {
       console.log(err.stack)
       process.exit(1)

--- a/bin/styled-svg.js
+++ b/bin/styled-svg.js
@@ -29,8 +29,8 @@ const optionsDefinitions = [
     type: Boolean
   },
   {
-    name: 'skip-tests',
-    description: 'Skip test file generation',
+    name: 'no-tests',
+    description: 'Prevents test file generation',
     type: Boolean
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3440,7 +3440,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3461,12 +3462,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3481,17 +3484,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3608,7 +3614,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3620,6 +3627,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3634,6 +3642,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3641,12 +3650,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3665,6 +3676,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3745,7 +3757,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3757,6 +3770,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3842,7 +3856,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3878,6 +3893,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3897,6 +3913,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3940,12 +3957,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -83,13 +83,13 @@ const convertFile = async (filePath, templates, options) => {
         .replace('\'##SIZES##\'', sizes),
       options
     ),
-    writeOut(
+    !options.skipTests ? writeOut(
       join(outputTestDir, testFilename),
       templates.test
         .replace('##FILENAME##', `${importRelativePath}/${componentFilename}`)
         .replace('##NAME##', displayName),
       options
-    )
+    ) : Promise.resolve()
   ])
 
   console.log('Converted',

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ const convertFile = async (filePath, templates, options) => {
         .replace('\'##SIZES##\'', sizes),
       options
     ),
-    !options.skipTests ? writeOut(
+    !options.noTests ? writeOut(
       join(outputTestDir, testFilename),
       templates.test
         .replace('##FILENAME##', `${importRelativePath}/${componentFilename}`)


### PR DESCRIPTION
Fixes #10

- Adds a `skip-tests` flag for skipping test file generation.
- Switches to a generic reducer to convert dash-case to camelCase options
