### PR TITLE
External helpers

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+semi: false
+singleQuote: true
+jsxSingleQuote: true

--- a/bin/styled-svg.js
+++ b/bin/styled-svg.js
@@ -85,7 +85,7 @@ if (options.help || options._unknown) {
 
   // execute on sources
   const globby = require('globby')
-  const convert = require('..')
+  const convert = require('../src/index')
 
   globby(normalizedOptions.input)
     .then(files => convert(files, normalizedOptions))

--- a/package-lock.json
+++ b/package-lock.json
@@ -6027,6 +6027,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+    },
     "pretty-format": {
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "styled-svg",
   "version": "2.3.4",
   "description": "Generates styled-components and tests from *.svg files",
-  "main": "src/index.js",
+  "main": "src/helpers.js",
+  "module": "src/helpers.js",
+  "sideEffects": false,
   "bin": {
     "styled-svg": "./bin/styled-svg.js"
   },
@@ -34,6 +36,7 @@
     "del": "^3.0.0",
     "fs-extra": "^7.0.1",
     "globby": "^9.0.0",
+    "prettier": "^1.18.2",
     "svgo": "1.1.0",
     "whatwg-fetch": "2.0.4"
   },

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,46 @@
+import { css } from 'styled-components'
+
+// somehow sizes is ending up in markup, even if it is not a valid svg attribute
+// until we have a better solution, just render it empty, instead to '[Object object]'
+export const sanitizeSizes = sizes =>
+  Object.defineProperty(sizes, 'toString', {
+    value: () => '',
+    enumerable: false
+  })
+
+export function createHelpers (width, height) {
+  const getDimensions = (size, sizes) => {
+    if (
+      size &&
+      typeof size.width === 'number' &&
+      typeof size.height === 'number'
+    ) {
+      return size
+    }
+
+    return size && sizes[size] ? sizes[size] : { width, height }
+  }
+
+  const getCss = (size, sizes, fillColor, fillColorRule, noStyles) => {
+    if (noStyles) {
+      return ''
+    }
+
+    const dimensions = getDimensions(size, sizes)
+    const fillRule =
+      fillColor && fillColorRule
+        ? `${fillColorRule}{ fill: ${fillColor}; }`
+        : ''
+
+    return css`
+      width: ${dimensions.width}px;
+      height: ${dimensions.height}px;
+      ${fillRule}
+    `
+  }
+
+  const propsToCss = ({ size, sizes, fillColor, fillColorRule, noStyles }) =>
+    getCss(size, sizes, fillColor, fillColorRule, noStyles)
+
+  return { getDimensions, getCss, propsToCss }
+}

--- a/src/optimize.js
+++ b/src/optimize.js
@@ -30,8 +30,7 @@ module.exports = content => {
       { sortAttrs: true }
     ]
   }
-  return new Promise(resolve => {
-    const svgo = new SVGO(svgoOptions)
-    svgo.optimize(content, res => resolve(res.data))
-  })
+
+  const svgo = new SVGO(svgoOptions)
+  return svgo.optimize(content, {})
 }

--- a/src/svgo-plugins/removeXmlns.js
+++ b/src/svgo-plugins/removeXmlns.js
@@ -1,6 +1,7 @@
 module.exports = {
   type: 'perItem',
-  description: 'remove xmlns AND xmlns:xlink, because { removeXMLNS: true } can not handle both',
+  description:
+    'remove xmlns, xmlns:xlink, because { removeXMLNS: true } can not handle both',
   fn: item => {
     item.eachAttr(attr => {
       if (attr.local && attr.prefix === 'xmlns') {

--- a/src/test-images/CheckedFocused.js
+++ b/src/test-images/CheckedFocused.js
@@ -1,90 +1,34 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
+import { createHelpers, sanitizeSizes } from 'styled-svg'
 
 const width = '14'
 const height = '14'
 const viewBox = '0 0 14 14'
 
-const sizes = {
+const sizes = sanitizeSizes({
   small: { width: 18, height: 18 },
   medium: { width: 24, height: 24 },
   large: { width: 36, height: 36 }
-}
+})
 
-// somehow sizes is ending up in markup, even if it is not a valid svg attribute
-// until we have a better solution, just render it empty, instead to '[Object object]'
-Object.defineProperty(sizes, 'toString', { value: () => '', enumerable: false })
+const { getDimensions, getCss, propsToCss } = createHelpers(width, height)
 
-const getDimensions = (size, sizes) => {
-  if (size && typeof size.width === 'number' && typeof size.height === 'number') {
-    return size
-  }
-  return size && sizes[size]
-    ? sizes[size]
-    : { width, height }
-}
-
-const getCss = (size, sizes, fillColor, fillColorRule, noStyles) => {
-  if (noStyles) { return '' }
-  const dimensions = getDimensions(size, sizes)
-  const fillRule = fillColor && fillColorRule ? `${fillColorRule}{ fill: ${fillColor}; }` : ''
-  return css`
-    width: ${dimensions.width}px;
-    height: ${dimensions.height}px;
-    ${fillRule}
-  `
-}
-
-const propsToCss = ({
-  size,
-  sizes,
-  fillColor,
-  fillColorRule,
-  noStyles
-}) => getCss(size, sizes, fillColor, fillColorRule, noStyles)
-
-const Image = styled.svg`${propsToCss}`
+const Image = styled.svg`
+  ${propsToCss}
+`
 
 const children = (
   <Fragment>
-    <defs
-      key='key-0'
-    >
-      <circle
-        id='s-c19cde862f-a'
-        cx='7'
-        cy='7'
-        r='7'
-      />
+    <defs key='key-0'>
+      <circle id='s-c19cde862f-a' cx='7' cy='7' r='7' />
     </defs>
-    <g
-      fill='none'
-      fillRule='evenodd'
-      key='key-1'
-    >
-      <use
-        fill='#FFF'
-        xlinkHref='#s-c19cde862f-a'
-      />
-      <circle
-        cx='7'
-        cy='7'
-        r='6.5'
-        stroke='#FF7500'
-      />
-      <circle
-        cx='7'
-        cy='7'
-        r='7.5'
-        stroke='#FFF'
-      />
-      <circle
-        cx='7'
-        cy='7'
-        r='3'
-        fill='#FF7500'
-      />
+    <g fill='none' fillRule='evenodd' key='key-1'>
+      <use fill='#FFF' xlinkHref='#s-c19cde862f-a' />
+      <circle cx='7' cy='7' r='6.5' stroke='#FF7500' />
+      <circle cx='7' cy='7' r='7.5' stroke='#FFF' />
+      <circle cx='7' cy='7' r='3' fill='#FF7500' />
     </g>
   </Fragment>
 )

--- a/src/test-images/CheckedFocused.test.js
+++ b/src/test-images/CheckedFocused.test.js
@@ -49,6 +49,6 @@ describe('CheckedFocused.svg generated styled component', () => {
   it('returns styles with getCss method', () => {
     const fillColor = '#ff0000'
     const fillRule = '&&& path, &&& use, &&& g'
-    expect(Image.getCss('medium', sizes, fillColor, fillRule)).toEqual([ '\n    width: ', String(sizes.medium.width), 'px;\n    height: ', String(sizes.medium.height), 'px;\n    ', `${fillRule}{ fill: ${fillColor}; }`, '\n  ' ])
+    expect(Image.getCss('medium', sizes, fillColor, fillRule)).toEqual([ '\n      width: ', String(sizes.medium.width), 'px;\n      height: ', String(sizes.medium.height), 'px;\n      ', `${fillRule}{ fill: ${fillColor}; }`, '\n    ' ])
   })
 })

--- a/src/test-images/Logo.js
+++ b/src/test-images/Logo.js
@@ -1,58 +1,27 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
+import { createHelpers, sanitizeSizes } from 'styled-svg'
 
 const width = '116'
 const height = '56'
 const viewBox = '0 0 116 56'
 
-const sizes = {
+const sizes = sanitizeSizes({
   small: { width: 18, height: 18 },
   medium: { width: 24, height: 24 },
   large: { width: 36, height: 36 }
-}
+})
 
-// somehow sizes is ending up in markup, even if it is not a valid svg attribute
-// until we have a better solution, just render it empty, instead to '[Object object]'
-Object.defineProperty(sizes, 'toString', { value: () => '', enumerable: false })
+const { getDimensions, getCss, propsToCss } = createHelpers(width, height)
 
-const getDimensions = (size, sizes) => {
-  if (size && typeof size.width === 'number' && typeof size.height === 'number') {
-    return size
-  }
-  return size && sizes[size]
-    ? sizes[size]
-    : { width, height }
-}
-
-const getCss = (size, sizes, fillColor, fillColorRule, noStyles) => {
-  if (noStyles) { return '' }
-  const dimensions = getDimensions(size, sizes)
-  const fillRule = fillColor && fillColorRule ? `${fillColorRule}{ fill: ${fillColor}; }` : ''
-  return css`
-    width: ${dimensions.width}px;
-    height: ${dimensions.height}px;
-    ${fillRule}
-  `
-}
-
-const propsToCss = ({
-  size,
-  sizes,
-  fillColor,
-  fillColorRule,
-  noStyles
-}) => getCss(size, sizes, fillColor, fillColorRule, noStyles)
-
-const Image = styled.svg`${propsToCss}`
+const Image = styled.svg`
+  ${propsToCss}
+`
 
 const children = (
   <Fragment>
-    <path
-      fill='#003468'
-      d='M0 0v27h116V0H0z'
-      key='key-0'
-    />
+    <path fill='#003468' d='M0 0v27h116V0H0z' key='key-0' />
     <path
       fill='#FF7500'
       d='M0 56h102.33c7.605 0 13.67-6.225 13.67-13.521V29H0v27z'

--- a/src/test-images/Logo.test.js
+++ b/src/test-images/Logo.test.js
@@ -49,6 +49,6 @@ describe('Logo.svg generated styled component', () => {
   it('returns styles with getCss method', () => {
     const fillColor = '#ff0000'
     const fillRule = '&&& path, &&& use, &&& g'
-    expect(Image.getCss('medium', sizes, fillColor, fillRule)).toEqual([ '\n    width: ', String(sizes.medium.width), 'px;\n    height: ', String(sizes.medium.height), 'px;\n    ', `${fillRule}{ fill: ${fillColor}; }`, '\n  ' ])
+    expect(Image.getCss('medium', sizes, fillColor, fillRule)).toEqual([ '\n      width: ', String(sizes.medium.width), 'px;\n      height: ', String(sizes.medium.height), 'px;\n      ', `${fillRule}{ fill: ${fillColor}; }`, '\n    ' ])
   })
 })

--- a/src/test-images/Warning.js
+++ b/src/test-images/Warning.js
@@ -1,58 +1,27 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
+import { createHelpers, sanitizeSizes } from 'styled-svg'
 
 const width = '18'
 const height = '18'
 const viewBox = '0 0 18 18'
 
-const sizes = {
+const sizes = sanitizeSizes({
   small: { width: 18, height: 18 },
   medium: { width: 24, height: 24 },
   large: { width: 36, height: 36 }
-}
+})
 
-// somehow sizes is ending up in markup, even if it is not a valid svg attribute
-// until we have a better solution, just render it empty, instead to '[Object object]'
-Object.defineProperty(sizes, 'toString', { value: () => '', enumerable: false })
+const { getDimensions, getCss, propsToCss } = createHelpers(width, height)
 
-const getDimensions = (size, sizes) => {
-  if (size && typeof size.width === 'number' && typeof size.height === 'number') {
-    return size
-  }
-  return size && sizes[size]
-    ? sizes[size]
-    : { width, height }
-}
-
-const getCss = (size, sizes, fillColor, fillColorRule, noStyles) => {
-  if (noStyles) { return '' }
-  const dimensions = getDimensions(size, sizes)
-  const fillRule = fillColor && fillColorRule ? `${fillColorRule}{ fill: ${fillColor}; }` : ''
-  return css`
-    width: ${dimensions.width}px;
-    height: ${dimensions.height}px;
-    ${fillRule}
-  `
-}
-
-const propsToCss = ({
-  size,
-  sizes,
-  fillColor,
-  fillColorRule,
-  noStyles
-}) => getCss(size, sizes, fillColor, fillColorRule, noStyles)
-
-const Image = styled.svg`${propsToCss}`
+const Image = styled.svg`
+  ${propsToCss}
+`
 
 const children = (
   <Fragment>
-    <g
-      fill='none'
-      fillRule='evenodd'
-      key='key-0'
-    >
+    <g fill='none' fillRule='evenodd' key='key-0'>
       <path
         fill='#FFCF29'
         d='M7.236 1.095L5.68 4.193.204 15.143A2 2 0 0 0 2.011 18h14a2 2 0 0 0 2-2c0-.306-.074-.592-.197-.851l-5.47-10.956-1.558-3.098A1.993 1.993 0 0 0 9.011 0c-.777 0-1.443.448-1.775 1.095z'

--- a/src/test-images/Warning.test.js
+++ b/src/test-images/Warning.test.js
@@ -49,6 +49,6 @@ describe('Warning.svg generated styled component', () => {
   it('returns styles with getCss method', () => {
     const fillColor = '#ff0000'
     const fillRule = '&&& path, &&& use, &&& g'
-    expect(Image.getCss('medium', sizes, fillColor, fillRule)).toEqual([ '\n    width: ', String(sizes.medium.width), 'px;\n    height: ', String(sizes.medium.height), 'px;\n    ', `${fillRule}{ fill: ${fillColor}; }`, '\n  ' ])
+    expect(Image.getCss('medium', sizes, fillColor, fillRule)).toEqual([ '\n      width: ', String(sizes.medium.width), 'px;\n      height: ', String(sizes.medium.height), 'px;\n      ', `${fillRule}{ fill: ${fillColor}; }`, '\n    ' ])
   })
 })

--- a/templates/component.js
+++ b/templates/component.js
@@ -1,50 +1,21 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
+import { createHelpers, sanitizeSizes } from 'styled-svg'
 
 const width = '##WIDTH##'
 const height = '##HEIGHT##'
 const viewBox = '##VIEWBOX##'
 
-const sizes = '##SIZES##'
+const sizes = sanitizeSizes('##SIZES##')
 
-// somehow sizes is ending up in markup, even if it is not a valid svg attribute
-// until we have a better solution, just render it empty, instead to '[Object object]'
-Object.defineProperty(sizes, 'toString', { value: () => '', enumerable: false })
-
-const getDimensions = (size, sizes) => {
-  if (size && typeof size.width === 'number' && typeof size.height === 'number') {
-    return size
-  }
-  return size && sizes[size]
-    ? sizes[size]
-    : { width, height }
-}
-
-const getCss = (size, sizes, fillColor, fillColorRule, noStyles) => {
-  if (noStyles) { return '' }
-  const dimensions = getDimensions(size, sizes)
-  const fillRule = fillColor && fillColorRule ? `${fillColorRule}{ fill: ${fillColor}; }` : ''
-  return css`
-    width: ${dimensions.width}px;
-    height: ${dimensions.height}px;
-    ${fillRule}
-  `
-}
-
-const propsToCss = ({
-  size,
-  sizes,
-  fillColor,
-  fillColorRule,
-  noStyles
-}) => getCss(size, sizes, fillColor, fillColorRule, noStyles)
+const { getDimensions, getCss, propsToCss } = createHelpers(width, height)
 
 const Image = styled.svg`${propsToCss}`
 
 const children = (
   <Fragment>
-    ##SVG##
+##SVG##
   </Fragment>
 )
 

--- a/templates/test.js
+++ b/templates/test.js
@@ -49,6 +49,6 @@ describe('##NAME##.svg generated styled component', () => {
   it('returns styles with getCss method', () => {
     const fillColor = '#ff0000'
     const fillRule = '&&& path, &&& use, &&& g'
-    expect(Image.getCss('medium', sizes, fillColor, fillRule)).toEqual([ '\n    width: ', String(sizes.medium.width), 'px;\n    height: ', String(sizes.medium.height), 'px;\n    ', `${fillRule}{ fill: ${fillColor}; }`, '\n  ' ])
+    expect(Image.getCss('medium', sizes, fillColor, fillRule)).toEqual([ '\n      width: ', String(sizes.medium.width), 'px;\n      height: ', String(sizes.medium.height), 'px;\n      ', `${fillRule}{ fill: ${fillColor}; }`, '\n    ' ])
   })
 })


### PR DESCRIPTION
This PR moves the inlined helpers of each converted SVG into this module itself.

This saves some space, especially when using a lot of icons.

In my measured case this meant around ~5KiB of JavaScript **after** gzip.