### PR TITLE
Directly assign PropTypes to be able to be stripped away

### DIFF
--- a/templates/component.js
+++ b/templates/component.js
@@ -29,7 +29,7 @@ const defaultProps = {
   size: null
 }
 
-const propTypes = {
+Image.propTypes = {
   fillColor: PropTypes.string,
   fillColorRule: PropTypes.string,
   viewBox: PropTypes.string.isRequired,
@@ -51,6 +51,5 @@ export default Object.assign(Image, {
   getDimensions,
   getCss,
   defaultProps,
-  propTypes,
   displayName: '##NAME##'
 })

--- a/templates/component.js
+++ b/templates/component.js
@@ -29,7 +29,7 @@ const defaultProps = {
   size: null
 }
 
-Image.propTypes = {
+Image.propTypes /* remove-proptypes */ = {
   fillColor: PropTypes.string,
   fillColorRule: PropTypes.string,
   viewBox: PropTypes.string.isRequired,


### PR DESCRIPTION
This PR changes the propTypes property to be directly assigned to the Component definition. Without this, the babel-plugin is not able to strip these prop types away in production mode.