### PR TITLE
Update main and module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "styled-svg",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Generates styled-components and tests from *.svg files",
-  "main": "src/createHelpers.js",
-  "module": "src/createHelpers.js",
+  "main": "src/index.js",
+  "module": "src/index.js",
   "sideEffects": false,
   "bin": {
     "styled-svg": "./bin/styled-svg.js"


### PR DESCRIPTION
It is impossible to use this module programmatically in JS when all that is exported are the `createHelpers`. This fix aligns the package with the [official docs](https://www.npmjs.com/package/styled-svg#js-usage)