### PR TITLE
Develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-svg",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/indent.js
+++ b/src/indent.js
@@ -10,7 +10,9 @@ const indentBase = 2
 const indentLine = indentLevel => str => ' '.repeat(indentLevel) + str
 const getStyleAttribute = str => {
   const trimmedStr = str.trim()
-  const props = trimmedStr.substring('style="'.length, trimmedStr.length - 1).split(';')
+  const props = trimmedStr
+    .substring('style="'.length, trimmedStr.length - 1)
+    .split(';')
   return [
     'style={{',
     ...props.map(prop => {
@@ -21,46 +23,64 @@ const getStyleAttribute = str => {
   ]
 }
 
-module.exports = svg => svg
-  .split('\n')
-  .reduce((buffer, line, lineIndex) => {
-    const matches = line.match(tagWithAttributes)
-    if (!matches) { return buffer }
-    const closingTag = matches[1] === '</'
-    const tag = matches[2]
-    const attrsStr = matches[3]
-    const autoclosingTag = matches[4] === '/>'
-    const indentLevel = line.match(leadingSpaces)[1].length
-    const indentParentLine = indentLine(indentLevel + indentBase)
-    const indentChildLine = indentLine(indentLevel + indentBase + 2)
-    const attributes = (attrsStr.match(attributesAndValues) || [])
-      .map(str => {
-        const [key, val] = str
-          .trim()
-          .replace(doubleQuotes, '\'')
-          .split('=')
-        if (key === 'class') { return null }
-        if (key === 'style') {
-          return getStyleAttribute(str)
-            .map(indentChildLine)
-            .join('\n')
-        }
-        return indentChildLine(`${camelCase(key)}=${val}`)
-      })
-      .filter(line => line)
-      .join('\n')
+module.exports = svg => {
+  const inlineReg = /(<\s*[^>]*>)(.*?)(<\s*\/\s*[a-z]+>)/g
 
-    if (tag === 'svg') { return buffer }
+  return svg
+    .split('\n')
+    .reduce((buffer, line, lineIndex) => {
+      if(line.match(inlineReg)){
+        return buffer.concat(line.replace(/> </g, '><'))
+      }
+      const matches = line.match(tagWithAttributes)
+      if (!matches) {
+        return buffer
+      }
+      const closingTag = matches[1] === '</'
+      const tag = matches[2]
+      const attrsStr = matches[3]
+      const autoclosingTag = matches[4] === '/>'
+      const indentLevel = line.match(leadingSpaces)[1].length
+      const indentParentLine = indentLine(indentLevel + indentBase)
+      const indentChildLine = indentLine(indentLevel + indentBase + 2)
 
-    return buffer.concat((closingTag
-      ? ([indentParentLine(`</${tag}>`)])
-      : ([
-        indentParentLine(`<${tag}`),
-        attributes,
-        indentParentLine(autoclosingTag ? '/>' : '>')
-      ]))
-      .filter(line => line)
-      .join('\n'))
-  }, [])
-  .join('\n')
-  .trim()
+      const attributes = (attrsStr.match(attributesAndValues) || [])
+        .map(str => {
+          const [key, val] = str
+            .trim()
+            .replace(doubleQuotes, "'")
+            .split('=')
+          if (key === 'class') {
+            return null
+          }
+          if (key === 'style') {
+            return getStyleAttribute(str)
+              .map(indentChildLine)
+              .join('\n')
+          }
+          return indentChildLine(`${camelCase(key)}=${val}`)
+        })
+        .filter(line => line)
+        .join('\n')
+
+      if (tag === 'svg') {
+        debugger;
+        return buffer
+      }
+
+      return buffer.concat(
+        (closingTag
+          ? [indentParentLine(`</${tag}>`)]
+          : [
+              indentParentLine(`<${tag}`),
+              attributes,
+              indentParentLine(autoclosingTag ? '/>' : '>')
+            ]
+        )
+          .filter(line => line)
+          .join('\n')
+      )
+    }, [])
+    .join('\n')
+    .trim()
+}

--- a/src/index.js
+++ b/src/index.js
@@ -29,15 +29,18 @@ const convertFile = async (filePath, templates, options) => {
   let viewBox = [0, 0, 0, 0]
 
   // determine names
-  const displayName = pascalCase(path.basename(filePath).replace(endsWithSvg, ''))
+  const displayName = pascalCase(
+    path.basename(filePath).replace(endsWithSvg, '')
+  )
   const componentFilename = `${displayName}.js`
-  const testFilename = `${displayName }.test.js`
+  const testFilename = `${displayName}.test.js`
 
   // resolve paths
   const testDir = options.testDir || './'
   const outputDir = options.outputDir || path.dirname(filePath)
   const outputTestDir = join(outputDir, testDir)
-  const importRelativePath = path.relative(outputTestDir, outputDir).replace(path.sep, '/') || '.'
+  const importRelativePath =
+    path.relative(outputTestDir, outputDir).replace(path.sep, '/') || '.'
 
   // load file content
   const origContent = await fs.readFile(filePath, 'utf8')
@@ -66,6 +69,8 @@ const convertFile = async (filePath, templates, options) => {
   // run SVG optimizers
   const content = await optimize(origContent)
 
+  const formattedContent = indent(content.data)
+
   // handle size alias options
   const sizes = serializeSizes(options)
 
@@ -77,27 +82,33 @@ const convertFile = async (filePath, templates, options) => {
       join(outputDir, componentFilename),
       prettier.format(
         templates.component
-          .replace('##SVG##', content.data)
+          .replace('##SVG##', formattedContent)
           .replace('##WIDTH##', viewBox[2])
           .replace('##HEIGHT##', viewBox[3])
           .replace('##VIEWBOX##', viewBox.join(' '))
           .replace('##NAME##', displayName)
-          .replace('\'##SIZES##\'', sizes)
-          .replace('\'##CREATEHELPERS##\'', createHelpers.toString()),
+          .replace("'##SIZES##'", sizes)
+          .replace("'##CREATEHELPERS##'", createHelpers.toString()),
         prettierConfig
       ),
       options
     ),
-    !options.noTests ? writeOut(
-      join(outputTestDir, testFilename),
-      templates.test
-        .replace('##FILENAME##', `${importRelativePath}/${componentFilename}`)
-        .replace(/##NAME##/g, displayName),
-      options
-    ) : Promise.resolve()
+    !options.noTests
+      ? writeOut(
+        join(outputTestDir, testFilename),
+        templates.test
+          .replace(
+            '##FILENAME##',
+            `${importRelativePath}/${componentFilename}`
+          )
+          .replace(/##NAME##/g, displayName),
+        options
+      )
+      : Promise.resolve()
   ])
 
-  console.log('Converted',
+  console.log(
+    'Converted',
     filePath.replace(process.cwd(), '.'),
     ' => ',
     path.join(outputDir.replace(process.cwd(), '.'), displayName)
@@ -106,7 +117,8 @@ const convertFile = async (filePath, templates, options) => {
 
 module.exports = async (files, options) => {
   // load templates
-  const templatesDir = options.templatesDir || join(__dirname, '..', 'templates')
+  const templatesDir =
+    options.templatesDir || join(__dirname, '..', 'templates')
   const templates = {
     component: await fs.readFile(join(templatesDir, 'component.js'), 'utf8'),
     test: await fs.readFile(join(templatesDir, 'test.js'), 'utf8')
@@ -116,14 +128,10 @@ module.exports = async (files, options) => {
   if (options.clean) {
     const del = require('del')
     if (options.outputDir) {
-      await del([
-        join(options.outputDir, '*.js')
-      ])
+      await del([join(options.outputDir, '*.js')])
     }
     if (options.testDir) {
-      await del([
-        join(options.testDir, '*.test.js')
-      ])
+      await del([join(options.testDir, '*.test.js')])
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ const convertFile = async (filePath, templates, options) => {
 
   // determine names
   const displayName = pascalCase(path.basename(filePath).replace(endsWithSvg, ''))
-  const componentFilename = displayName + '.js'
-  const testFilename = displayName + '.test.js'
+  const componentFilename = `${displayName}.js`
+  const testFilename = `${displayName }.test.js`
 
   // resolve paths
   const testDir = options.testDir || './'
@@ -66,9 +66,6 @@ const convertFile = async (filePath, templates, options) => {
   // run SVG optimizers
   const content = await optimize(origContent)
 
-  // react formatted SVG
-  const formattedContent = indent(content.data)
-
   // handle size alias options
   const sizes = serializeSizes(options)
 
@@ -80,7 +77,7 @@ const convertFile = async (filePath, templates, options) => {
       join(outputDir, componentFilename),
       prettier.format(
         templates.component
-          .replace('##SVG##', formattedContent)
+          .replace('##SVG##', content.data)
           .replace('##WIDTH##', viewBox[2])
           .replace('##HEIGHT##', viewBox[3])
           .replace('##VIEWBOX##', viewBox.join(' '))


### PR DESCRIPTION
Hello, first of all, thank you for creating a good library.

Using the library caused an issue where the end tag was disappearing in the following situations:

For example, when you say that there are svg files,

### best.svg

    
     <svg xmlns="http://www.w3.org/2000/svg" width="48" height="19" viewBox="0 0 48 19">
         <g fill="none" fill-rule="benodd">
             <Right width="48" height="19" fill="currentColor" rx="9.5" />
             <text fill="#FFF" font-family="NotoSansCJKr-Medium, Noto Sans CJK KR" font-size="11" font-weight="400" letter-spacing="-"-"-"-"-"-"-"-"-"-"-"-"-"-"-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""275">
    	          < tspan x="11" y="13">BEST</tspan>
    	   </text>
         </gg
     </svg>

### svg/src/index.js
const formattedContent = indent(content.data)

When that part is executed 

Inline tags will only recognize the tag at the beginning of the regular expression in TagWithAttributes.

Therefore, the following ‘BEST’ TEXT and `tspan` disappear.

    // ...
    	< tspan x="11" y="13">
    //            BEST
    //         </tspan> removed
    	   </text>
    	 </g>
     </svg>

So we want to address that issue as follows:

Use regular expressions to recognize inline tags.

    constlineReg = /(<\s*[^]]])((.*?)(<\s*\/\s*[a-z]+>)/g

If the line is recognized as an inline tag within the reduce function, return without executing the logic below.

    if(line.match(lineReg){
      return buffer.concat(/>  </g, ' '')
    }

It will now be compiled as normal as follows:

     <g fill="none" fillRule="benodd" key="key-0">
    			 <Right width="48" height="19" fill="currentColor" rx="9.5" />
    			 <text fill="#FFF" fontFamily="NotoSansCJKr-Medium, Noto Sans CJK KR" fontSize="11" fontWeight="400" letter-Spacing="-275">
    				 < tspan x="11" y="13">
    					BEST
    				 </tspan>
    // ...